### PR TITLE
Bump version tags

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install helm3
       run: |
-        wget https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz -O - | tar -xz
+        wget https://get.helm.sh/helm-v3.5.0-linux-amd64.tar.gz -O - | tar -xz
         sudo cp linux-amd64/helm /usr/local/bin/helm
     - name: Update dependencies
       run: helm dependency update

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 9.8.12
-digest: sha256:3606249cb7e59f741ae52c44f77ce9708198eaae9c2b1b5150a3720b497228f5
-generated: "2021-11-12T13:55:27.741605774+01:00"
+  version: 10.16.2
+digest: sha256:4dd3203f3c5accb616976649b2656c49f14017e3055ccbcc8b59180d57c3db36
+generated: "2022-10-12T15:20:41.374871417+02:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,4 +12,4 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 9.x.x
+    version: 10.x.x

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: beacon
 version: 0.0.1
-appVersion: 1.8.0
+appVersion: 1.9.0
 description: Python-based Beacon API Web Server
 home: https://beacon-python.readthedocs.io
 icon: https://nbis.se/assets/img/logos/nbislogo-green.svg

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: beacon
-version: 0.0.1
+version: 0.0.2
 appVersion: 1.9.0
 description: Python-based Beacon API Web Server
 home: https://beacon-python.readthedocs.io

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{- toYaml .Values.podAnnotations | nindent 8 -}}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -39,7 +39,7 @@ externalDatabase:
 
 image:
   repository: cscfi/beacon-python
-  tag: latest
+  tag: 1.9.0
   pullPolicy: IfNotPresent
 
 ingress:


### PR DESCRIPTION
Regular maintenance that dependabot should take care of, but since dependabot is not set up for this repo it has to be done manually.